### PR TITLE
Use resources#sha256 instead of deprecated sha1

### DIFF
--- a/girara.rb
+++ b/girara.rb
@@ -5,7 +5,7 @@
 class Girara < Formula
   homepage "https://pwmt.org/projects/girara/"
   url "https://pwmt.org/projects/girara/download/girara-0.2.6.tar.gz"
-  sha1 "674e4294fe091fe93a1c186d95b3263b30cd8a5e"
+  sha256 "674e4294fe091fe93a1c186d95b3263b30cd8a5e"
   version "0.2.6"
 
   # depends_on "cmake" => :build

--- a/zathura-pdf-poppler.rb
+++ b/zathura-pdf-poppler.rb
@@ -6,7 +6,7 @@ class ZathuraPdfPoppler < Formula
   homepage "https://pwmt.org/projects/zathura-pdf-poppler/"
   url "https://pwmt.org/projects/zathura-pdf-poppler/download/zathura-pdf-poppler-0.2.5.tar.gz"
   version "0.2.5"
-  sha1 "7baa6b12526c13c4088eb206147d6cb3539f53b8"
+  sha256 "7baa6b12526c13c4088eb206147d6cb3539f53b8"
 
   depends_on :x11 # if your formula requires any X11/XQuartz components
   depends_on 'zathura'
@@ -16,12 +16,12 @@ class ZathuraPdfPoppler < Formula
   # Apply patches from http://stackoverflow.com/a/29460237
   patch :p0 do
     url "https://raw.githubusercontent.com/zegervdv/homebrew-zathura/master/zathura-pdf-poppler-config.mk.diff"
-    sha1 "beebbe4112b84a1c2c196f7eede68390026e4dc7"
+    sha256 "beebbe4112b84a1c2c196f7eede68390026e4dc7"
   end
 
   patch :p0 do
     url "https://raw.githubusercontent.com/zegervdv/homebrew-zathura/master/zathura-pdf-poppler-Makefile.diff"
-    sha1 "2b70a49572e5cd538402a3e9968a1093f2762154"
+    sha256 "2b70a49572e5cd538402a3e9968a1093f2762154"
   end
 
   def install

--- a/zathura-ps.rb
+++ b/zathura-ps.rb
@@ -6,7 +6,7 @@ class ZathuraPs < Formula
   homepage "https://pwmt.org/projects/zathura-ps/"
   url "https://pwmt.org/projects/zathura-ps/download/zathura-ps-0.2.2.tar.gz"
   version "0.2.2"
-  sha1 "35340171aa7dab6d2bed8a1b94a68ff5ee76e2eb"
+  sha256 "35340171aa7dab6d2bed8a1b94a68ff5ee76e2eb"
 
   depends_on :x11 # if your formula requires any X11/XQuartz components
   depends_on 'zathura'
@@ -14,12 +14,12 @@ class ZathuraPs < Formula
 
   patch :p0 do
     url 'https://github.com/zegervdv/homebrew-zathura/raw/master/zathura-ps-Makefile.patch'
-    sha1 '8c0ddb9b7e709376c437b0283306cc1f7c0f5b9a'
+    sha256 '8c0ddb9b7e709376c437b0283306cc1f7c0f5b9a'
   end
 
   patch :p0 do
     url 'https://github.com/zegervdv/homebrew-zathura/raw/master/zathura-ps-config.mk.patch'
-    sha1 '2303727d83fca7446d1d20825d22ca3e5b899dc0'
+    sha256 '2303727d83fca7446d1d20825d22ca3e5b899dc0'
   end
 
   def install

--- a/zathura.rb
+++ b/zathura.rb
@@ -6,7 +6,7 @@ class Zathura < Formula
   homepage "https://pwmt.org/projects/zathura/"
   url "https://pwmt.org/projects/zathura/download/zathura-0.3.4.tar.gz"
   version "0.3.4"
-  sha1 "d8142ffdd9df8f04619cc823da07afb1f7694270"
+  sha256 "d8142ffdd9df8f04619cc823da07afb1f7694270"
 
   # depends_on "cmake" => :build
   depends_on :x11 # if your formula requires any X11/XQuartz components
@@ -18,7 +18,7 @@ class Zathura < Formula
 
   patch :p0 do
     url "https://raw.githubusercontent.com/zegervdv/homebrew-zathura/master/zathura-main.c.patch"
-    sha1 "8bfffd0ac105f8094eb0019feeec23b9155985f4"
+    sha256 "8bfffd0ac105f8094eb0019feeec23b9155985f4"
   end
 
   def install


### PR DESCRIPTION
Removes the highly verbose deprecation warnings from Homebrew (see https://github.com/Homebrew/brew/issues/606).