### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ brew install zathura-pdf-poppler
 Follow the instructions to link the plugins into place:
 ```
 $ mkdir -p $(brew --prefix zathura)/lib/zathura
-$ ln -s $(brew --prefix zathura-pdf-poppler)/lib/pdf.dylib $(brew --prefix zathura)/lib/zathura/pdf.so
+$ ln -s $(brew --prefix zathura-pdf-poppler)/libpdf-poppler.dylib $(brew --prefix zathura)/lib/zathura/libpdf-poppler.dylib
 ```
 
 ### Copying to clipboard


### PR DESCRIPTION
In the current `README.md`, symlink instructions to enable zathura-pdf-poppler plugin remain the previous version. It should follow the latest caveats in `zathura-pdf-poppler.rb` to avoid confusion.