### PR TITLE
Change the repository for HEAD

### DIFF
--- a/girara.rb
+++ b/girara.rb
@@ -5,7 +5,7 @@
 class Girara < Formula
   homepage "https://pwmt.org/projects/girara/"
   url "https://github.com/pwmt/girara/archive/0.3.6.tar.gz"
-  head "https://git.pwmt.org/pwmt/girara.git", branch: "develop"
+  head "https://github.com/pwmt/girara.git", branch: "develop"
   sha256 "18f1028f4095c4a87e8137c0924becd77b5d8b2f778a5f7b8aa6d24f12d04a23"
   version "0.3.6"
 

--- a/zathura.rb
+++ b/zathura.rb
@@ -5,7 +5,7 @@
 class Zathura < Formula
   homepage "https://pwmt.org/projects/zathura/"
   url "https://github.com/pwmt/zathura/archive/0.4.8.tar.gz"
-  head "https://git.pwmt.org/pwmt/zathura.git", branch: "develop"
+  head "https://github.com/pwmt/zathura.git", branch: "develop"
   version "0.4.8"
   revision 0
   sha256 "7b53921a90ff29319588f604575348ef78fa55816d866bbdf7687a8972536c8f"


### PR DESCRIPTION
The old repository seems not working now, so I changed it into the github repository url