### PR TITLE
fix: add dependency `json-glib`

### DIFF
--- a/Formula/girara.rb
+++ b/Formula/girara.rb
@@ -12,6 +12,7 @@ class Girara < Formula
   depends_on "gettext"
   depends_on "gtk+3"
   depends_on "json-c"
+  depends_on "json-glib"
   depends_on "libnotify"
   depends_on "libpthread-stubs"
 


### PR DESCRIPTION
I tried to use OSX_native_integration, then I got
```
Raime@MacOS ~/.config % brew install zathura --HEAD
==> Fetching zegervdv/zathura/zathura
==> Cloning https://github.com/pwmt/zathura.git
Updating /Users/Raime/Library/Caches/Homebrew/zathura--git
==> Checking out branch develop
Already on 'develop'
Your branch is up to date with 'origin/develop'.
HEAD is now at 72533ba CI: reduce artifact lifetime
==> Installing zathura from zegervdv/zathura
==> meson ..
Last 15 lines from /Users/Raime/Library/Logs/Homebrew/zathura/01.meson:
Library m found: YES
Found pkg-config: /usr/local/Homebrew/Library/Homebrew/shims/mac/super/pkg-config (0.29.2)
Run-time dependency girara-gtk3 found: YES 0.4.0
Run-time dependency glib-2.0 found: YES 2.78.0
Run-time dependency gio-unix-2.0 found: YES 2.78.0
Run-time dependency gthread-2.0 found: YES 2.78.0
Run-time dependency gmodule-no-export-2.0 found: YES 2.78.0
Run-time dependency gtk+-3.0 found: YES 3.24.38
Found CMake: /usr/local/opt/cmake/bin/cmake (3.27.5)
Run-time dependency json-glib-1.0 found: NO (tried pkgconfig, framework and cmake)

../meson.build:46:12: ERROR: Dependency "json-glib-1.0" not found, tried pkgconfig, framework and cmake

A full log can be found at /private/tmp/zathura-20230916-54728-15q2h2a/build/meson-logs/meson-log.txt
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```

Yet I've executed `brew install json-glib` and `brew reinstall json-glib`, the error above remained. Thus I ran `brew edit girara` and added `depends_on "json-glib"`, it worked.