### PR TITLE
chore(deps): bump up the version for zathura and its plugins

### DIFF
--- a/Formula/zathura-cb.rb
+++ b/Formula/zathura-cb.rb
@@ -1,7 +1,7 @@
 class ZathuraCb < Formula
   desc "Comic book plugin for zathura"
   homepage "https://pwmt.org/projects/zathura-cb/"
-  url "https://github.com/pwmt/zathura-cb/archive/refs/tags/0.1.11.tar.gz"
+  url "https://github.com/pwmt/zathura-cb/archive/refs/tags/0.1.12.tar.gz"
   sha256 "4159a84bbff021087e60fb82c62505e6db5c19aa9962edda39a4b11d00302f5d"
   license "Zlib"
 

--- a/Formula/zathura-djvu.rb
+++ b/Formula/zathura-djvu.rb
@@ -1,7 +1,7 @@
 class ZathuraDjvu < Formula
   desc "DJVU plugin for zathura"
   homepage "https://pwmt.org/projects/zathura-djvu/"
-  url "https://github.com/pwmt/zathura-djvu/archive/refs/tags/0.2.10.tar.gz"
+  url "https://github.com/pwmt/zathura-djvu/archive/refs/tags/0.2.11.tar.gz"
   sha256 "3749fe9da14c5cbd13598c83f2dbff9c1c1d906797139fc809ef256f8075c987"
   license "Zlib"
 

--- a/Formula/zathura-pdf-mupdf.rb
+++ b/Formula/zathura-pdf-mupdf.rb
@@ -1,7 +1,7 @@
 class ZathuraPdfMupdf < Formula
   desc "MuPDF backend plugin for zathura"
   homepage "https://pwmt.org/projects/zathura-pdf-mupdf/"
-  url "https://github.com/pwmt/zathura-pdf-mupdf/archive/refs/tags/0.4.4.tar.gz"
+  url "https://github.com/pwmt/zathura-pdf-mupdf/archive/refs/tags/0.4.6.tar.gz"
   sha256 "90bdc7c0d4b5f6bd7b17f9c3832ae5eb8465b45d78ab3b8c2fca26ed45ed1177"
   license "Zlib"
 

--- a/Formula/zathura-pdf-poppler.rb
+++ b/Formula/zathura-pdf-poppler.rb
@@ -1,7 +1,7 @@
 class ZathuraPdfPoppler < Formula
   desc "Poppler backend plugin for zathura"
   homepage "https://pwmt.org/projects/zathura-pdf-poppler/"
-  url "https://github.com/pwmt/zathura-pdf-poppler/archive/refs/tags/0.3.3.tar.gz"
+  url "https://github.com/pwmt/zathura-pdf-poppler/archive/refs/tags/0.3.4.tar.gz"
   sha256 "bff865c712920c64d1393f87811b66bf79909fa7ee82364cf0cde7d5552613ea"
   license "Zlib"
 

--- a/Formula/zathura-ps.rb
+++ b/Formula/zathura-ps.rb
@@ -1,7 +1,7 @@
 class ZathuraPs < Formula
   desc "Postscript backend plugin for zathura"
   homepage "https://pwmt.org/projects/zathura-ps/"
-  url "https://github.com/pwmt/zathura-ps/archive/refs/tags/0.2.8.tar.gz"
+  url "https://github.com/pwmt/zathura-ps/archive/refs/tags/0.2.9.tar.gz"
   sha256 "b8b42c4517e4bdaee4c84c1c6e7298cabf00fc40b9b95f59feee0f61fe780b54"
   license "Zlib"
 

--- a/Formula/zathura.rb
+++ b/Formula/zathura.rb
@@ -1,7 +1,7 @@
 class Zathura < Formula
   desc "PDF viewer"
   homepage "https://pwmt.org/projects/zathura/"
-  url "https://github.com/pwmt/zathura/archive/refs/tags/0.5.11.tar.gz"
+  url "https://github.com/pwmt/zathura/archive/refs/tags/0.5.14.tar.gz"
   sha256 "32540747a6fe3c4189ec9d5de46a455862c88e11e969adb5bc0ce8f9b25b52d4"
   license "Zlib"
   head "https://github.com/pwmt/zathura.git", branch: "develop"


### PR DESCRIPTION
- Updated zathura from 0.5.11 to 0.5.14
- Updated zathura-cb from 0.1.11 to 0.1.12
- Updated zathura-djvu from 0.2.10 to 0.2.11
- Updated zathura-pdf-mupdf from 0.4.4 to 0.4.6
- Updated zathura-pdf-poppler from 0.3.3 to 0.3.4
- Updated zathura-ps from 0.2.8 to 0.2.9

cc: @SylvanFranklin