### PR TITLE
synctex: fix pkg-config metadata

### DIFF
--- a/Formula/synctex.rb
+++ b/Formula/synctex.rb
@@ -12,6 +12,7 @@ class Synctex < Formula
     regex(/^(\d{4})$/i)
   end
 
+  depends_on "pkgconf" => :test
   depends_on "zlib"
 
   def install
@@ -33,10 +34,10 @@ includedir=#{include}
 
 Name: synctex
 Description: SyncTeX parser library
-Version: 1.21.0
+Version: 2.0.0
 Requires.private: zlib
 Libs: -L${libdir} -lsynctex
-Cflags: -I${includedir}/synctex"
+Cflags: -I${includedir}"
     end
 
     mkdir "#{lib}/pkgconfig"
@@ -44,6 +45,23 @@ Cflags: -I${includedir}/synctex"
   end
 
   test do
-    system "true" # TODO
+    system "pkgconf", "--atleast-version=2", "synctex"
+    assert_match "-I#{include}", shell_output("pkgconf --cflags synctex")
+
+    (testpath/"test.c").write <<~C
+      #include <stddef.h>
+      #include <synctex/synctex_parser.h>
+
+      int main(void) {
+        synctex_scanner_p scanner = synctex_scanner_new_with_output_file("missing.pdf", NULL, 1);
+        if (scanner != NULL) {
+          synctex_scanner_free(scanner);
+        }
+        return 0;
+      }
+    C
+
+    flags = shell_output("pkgconf --cflags synctex").split
+    system ENV.cc, "test.c", *flags, "-c", "-o", "test.o"
   end
 end


### PR DESCRIPTION
## Summary

- advertise SyncTeX API version `2.0.0` in `synctex.pc`, satisfying Zathura's `synctex >= 2` requirement
- expose the include root so `#include <synctex/synctex_parser.h>` resolves correctly
- replace the no-op formula test with pkg-config version/include checks and a header compilation test

## Root cause

The formula generated `synctex.pc` with `Version: 1.21.0`, so Meson silently disabled SyncTeX while configuring current Zathura. Changing only the version exposed a second issue: `Cflags: -I${includedir}/synctex` made the compiler search for `synctex/synctex/synctex_parser.h`.

Fixes #169.

## Validation

Tested on macOS 26.3.1 (25D771280a), arm64, with Homebrew 6.0.9-110-gbc79adb, SyncTeX 2024, and Zathura 2026.02.09.

- `brew style Formula/synctex.rb`
- `brew audit --strict homebrew-zathura/zathura/synctex`
- `brew reinstall --build-from-source homebrew-zathura/zathura/synctex`
- `brew test homebrew-zathura/zathura/synctex`
- `brew reinstall --build-from-source homebrew-zathura/zathura/zathura --with-synctex`
- `brew test homebrew-zathura/zathura/zathura`
- Meson reports `Run-time dependency synctex found: YES 2.0.0`
- `otool -L` reports `/opt/homebrew/opt/synctex/lib/libsynctex.dylib`

## AI assistance disclosure

This PR was prepared with assistance from **ChatGPT / OpenAI Codex (GPT-5)**. The investigation, changes, builds, and validation commands above were reviewed and executed on the reporter's machine.
