### PR TITLE
fix: make the macOS title bar opaque

### DIFF
--- a/Formula/zathura.rb
+++ b/Formula/zathura.rb
@@ -11,6 +11,8 @@ class Zathura < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
+  option "with-no-titlebar", "Remove the title bar on macOS"
+
   depends_on "cmake" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
@@ -28,24 +30,19 @@ class Zathura < Formula
   on_macos do
     depends_on "gtk+3"
     depends_on "gtk-mac-integration"
-  end
-
-  patch do
-    url "file://#{__dir__}/../patches/mac-integration.diff"
-    sha256 "8c8b1546d18418c1c43579365bd810a022b30c655edc60364d1867ee4b3ba00f"
-  end
-
-  on_macos do
-    option "with-no-titlebar", "Remove the title bar on macOS"
 
     if build.with? "no-titlebar"
       # Optionally remove the title bar on macOS with the "-T" or "--no-titlebar" arguments
       patch do
         url "file://#{__dir__}/../patches/no-titlebar.diff"
-        sha256 "5243224b088bcbac7bfce93322d58b8bd23a6d4011d9395040ed1f897ae569ad"
+        sha256 "2cbe0a3ec8c9baf675c44f460df192436367e6ad984c58c53d1266d69664e197"
       end
     end
-    
+  end
+
+  patch do
+    url "file://#{__dir__}/../patches/mac-integration.diff"
+    sha256 "b82c8206402015b4664ddf3f93fa0aff54d75402b28317f16dd5e5b7bc40e2d0"
   end
 
   def install

--- a/Formula/zathura.rb
+++ b/Formula/zathura.rb
@@ -42,7 +42,7 @@ class Zathura < Formula
 
   patch do
     url "file://#{__dir__}/../patches/mac-integration.diff"
-    sha256 "b82c8206402015b4664ddf3f93fa0aff54d75402b28317f16dd5e5b7bc40e2d0"
+    sha256 "01cc955bed34aa98d46d9e8939cb38ae924ee263a0a12d68716d9ebbd3b6fed3"
   end
 
   def install

--- a/patches/mac-integration.diff
+++ b/patches/mac-integration.diff
@@ -31,10 +31,18 @@ index fe621cb..bbe9d07 100644
        ;;
    esac
 diff --git a/meson.build b/meson.build
-index eecb9c1..f2c9018 100644
+index 65a9194..ccd26f8 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -74,10 +74,6 @@ defines = [
+@@ -57,6 +57,7 @@ sqlite = dependency('sqlite3', version: '>=3.6.23')
+ build_dependencies = [libm, girara, glib, gio, gthread, gmodule, gtk3, cairo, magic, json_glib]
+ 
+ if host_machine.system() == 'darwin'
++  add_languages('objc', native: false)
+   gtk_mac_integration = dependency('gtk-mac-integration-gtk3')
+   build_dependencies += gtk_mac_integration
+ endif
+@@ -73,10 +74,6 @@ defines = [
    '-D_DEFAULT_SOURCE',
  ]
  
@@ -45,7 +53,7 @@ index eecb9c1..f2c9018 100644
  # compile flags
  flags = [
    '-Werror=implicit-function-declaration',
-@@ -156,6 +152,15 @@ headers = files(
+@@ -164,6 +161,15 @@ headers = files(
  )
  headers += version_header
  
@@ -164,7 +172,7 @@ index 0000000..07365e6
 +
 +#endif /* MAC_INTEGRATION_H */
 diff --git a/zathura/main.c b/zathura/main.c
-index 8f7b0d8..2f983c7 100644
+index a439a78..7377272 100644
 --- a/zathura/main.c
 +++ b/zathura/main.c
 @@ -1,7 +1,7 @@
@@ -176,8 +184,8 @@ index 8f7b0d8..2f983c7 100644
 +#include "mac-integration.h"
  #endif
  
- #include <girara/settings.h>
-@@ -259,17 +259,9 @@ GIRARA_VISIBLE int main(int argc, char* argv[]) {
+ #include <girara-gtk/settings.h>
+@@ -283,17 +283,9 @@ GIRARA_VISIBLE int main(int argc, char* argv[]) {
      return -1;
    }
  

--- a/patches/mac-integration.diff
+++ b/patches/mac-integration.diff
@@ -31,7 +31,7 @@ index fe621cb..bbe9d07 100644
        ;;
    esac
 diff --git a/meson.build b/meson.build
-index 65a9194..ccd26f8 100644
+index 65a9194..d5b8eaa 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -57,6 +57,7 @@ sqlite = dependency('sqlite3', version: '>=3.6.23')
@@ -60,9 +60,9 @@ index 65a9194..ccd26f8 100644
 +if host_machine.system() == 'darwin'
 +  sources += files(
 +    'zathura/mac-integration.c',
-+  )
-+  sources += files(
 +    'zathura/mac-integration.h',
++    'zathura/mac-window.m',
++    'zathura/mac-window.h',
 +  )
 +endif
 +
@@ -171,6 +171,63 @@ index 0000000..07365e6
 +void zathura_mac_init(zathura_t* zathura);
 +
 +#endif /* MAC_INTEGRATION_H */
+diff --git a/zathura/mac-window.h b/zathura/mac-window.h
+new file mode 100644
+index 0000000..a841ddf
+--- /dev/null
++++ b/zathura/mac-window.h
+@@ -0,0 +1,17 @@
++/* SPDX-License-Identifier: Zlib */
++
++#ifndef MAC_WINDOW_H
++#define MAC_WINDOW_H
++
++#include <gtk/gtk.h>
++
++#ifdef GDK_WINDOWING_QUARTZ
++/**
++ * Set up macOS-specific window properties.
++ *
++ * @param window The GTK window
++ */
++void zathura_macos_set_window_background(GtkWindow* window);
++#endif
++
++#endif /* MAC_WINDOW_H */
+diff --git a/zathura/mac-window.m b/zathura/mac-window.m
+new file mode 100644
+index 0000000..91cf3da
+--- /dev/null
++++ b/zathura/mac-window.m
+@@ -0,0 +1,28 @@
++/* SPDX-License-Identifier: Zlib */
++
++#include <gdk/gdkquartz.h>
++#include <gtk/gtk.h>
++#import <AppKit/AppKit.h>
++
++#include "mac-window.h"
++
++extern NSWindow* gdk_quartz_window_get_nswindow(GdkWindow* window);
++
++void zathura_macos_set_window_background(GtkWindow* window) {
++  if (window == NULL) {
++    return;
++  }
++
++  GdkWindow* gdk_window = gtk_widget_get_window(GTK_WIDGET(window));
++  if (gdk_window == NULL) {
++    return;
++  }
++
++  NSWindow* ns_window = gdk_quartz_window_get_nswindow(gdk_window);
++  if (ns_window == nil) {
++    return;
++  }
++
++  /* GTK uses a clear NSWindow background for client-side decorations. */
++  [ns_window setBackgroundColor:[NSColor windowBackgroundColor]];
++}
 diff --git a/zathura/main.c b/zathura/main.c
 index a439a78..7377272 100644
 --- a/zathura/main.c
@@ -206,3 +263,26 @@ index a439a78..7377272 100644
  
    /* run zathura */
    gtk_main();
+diff --git a/zathura/zathura.c b/zathura/zathura.c
+index e10e0bc..3ffb80b 100644
+--- a/zathura/zathura.c
++++ b/zathura/zathura.c
+@@ -41,6 +41,7 @@
+ #include "zathura.h"
+ #include "utils.h"
+ #include "marks.h"
++#include "mac-window.h"
+ #include "render.h"
+ #include "page.h"
+ #include "page-widget.h"
+@@ -221,6 +222,10 @@ static bool init_ui(zathura_t* zathura) {
+     return false;
+   }
+ 
++#ifdef GDK_WINDOWING_QUARTZ
++  zathura_macos_set_window_background(GTK_WINDOW(zathura->ui.session->gtk.window));
++#endif
++
+   /* girara events */
+   zathura->ui.session->events.buffer_changed  = cb_buffer_changed;
+   zathura->ui.session->events.unknown_command = cb_unknown_command;

--- a/patches/no-titlebar.diff
+++ b/patches/no-titlebar.diff
@@ -1,11 +1,8 @@
 diff --git a/meson.build b/meson.build
-index b42ad22..18252b6 100644
+index 65a9194..c0ee3d7 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1 +1 @@
--project('zathura', 'c',
-+project('zathura', ['c', 'objc'],
-@@ -151,6 +151,7 @@ sources = files(
+@@ -150,6 +150,7 @@ sources = files(
    'zathura/types.c',
    'zathura/utils.c',
    'zathura/zathura.c',
@@ -112,7 +109,7 @@ index a439a78..41ade45 100644
      girara_error("Could not initialize zathura.");
      return -1;
 diff --git a/zathura/zathura.c b/zathura/zathura.c
-index a754098..65516ac 100644
+index e10e0bc..fc154ea 100644
 --- a/zathura/zathura.c
 +++ b/zathura/zathura.c
 @@ -22,6 +22,8 @@
@@ -132,30 +129,28 @@ index a754098..65516ac 100644
  
    /* initialize with default paths */
    {
-@@ -220,7 +223,13 @@ static bool init_ui(zathura_t* zathura) {
-     girara_error("Failed to initialize girara.");
-     return false;
-   }
--
-+  
-+  #ifdef GDK_WINDOWING_QUARTZ
-+    if (zathura->global.no_titlebar) {
-+      setup_macos_window(GTK_WINDOW(zathura->ui.session->gtk.window));
-+    }
-+  #endif
-+  
-   /* girara events */
+@@ -225,6 +228,12 @@ static bool init_ui(zathura_t* zathura) {
    zathura->ui.session->events.buffer_changed  = cb_buffer_changed;
    zathura->ui.session->events.unknown_command = cb_unknown_command;
+ 
++#ifdef GDK_WINDOWING_QUARTZ
++  if (zathura->global.no_titlebar) {
++    setup_macos_window(GTK_WINDOW(zathura->ui.session->gtk.window));
++  }
++#endif
++
+   /* gestures */
+ 
+   GtkGesture* zoom = gtk_gesture_zoom_new(GTK_WIDGET(zathura->ui.session->gtk.view));
 diff --git a/zathura/zathura.h b/zathura/zathura.h
-index 11b3101..2ff727c 100644
+index 3dd93b7..631e5aa 100644
 --- a/zathura/zathura.h
 +++ b/zathura/zathura.h
-@@ -147,6 +147,7 @@ struct zathura_s {
+@@ -149,6 +149,7 @@ struct zathura_s {
      GdkModifierType synctex_edit_modmask; /**< Modifier to trigger synctex edit */
      GdkModifierType highlighter_modmask;  /**< Modifier to draw with a highlighter */
      bool double_click_follow;             /**< Double/Single click to follow link */
 +    bool no_titlebar;                     /**< Disable title bar on macOS */
      GtkTreePath* current_index_path;      /**< Current index path */
    } global;
-   
+ 


### PR DESCRIPTION
- set Zathura's native `NSWindow` background to the semantic `NSColor.windowBackgroundColor` on macOS
- compile the small Objective-C window bridge only on Darwin
- update the optional `--with-no-titlebar` patch so it still applies and builds with the macOS integration patch
- update both patch checksums and bring the touched formula into current `brew style` order

Before:
<img width="800" height="90" alt="titlebar-before" src="https://github.com/user-attachments/assets/21da404a-7757-4ccc-b256-faaf6da5d01a" />

After:
<img width="800" height="90" alt="titlebar-after" src="https://github.com/user-attachments/assets/f1a7d0e1-836d-4b96-9ef6-8a82e32f7b1d" />

Tested on:

- macOS 27.0 (26A5378n)
- Zathura 2026.02.09
- GTK 3.24.52
- gtk-mac-integration 3.0.2
- Girara 2026.07.18